### PR TITLE
Upgrade AVA to 0.14

### DIFF
--- a/app/test-frameworks.js
+++ b/app/test-frameworks.js
@@ -10,7 +10,7 @@ var testFrameworksHash = {
     deps: ['tap-spec@^4.1.1', 'tape@^4.4.0', 'chokidar-cli@^1.2.0'],
   },
   ava: {
-    test: 'ava --require babel-register --timeout=2s',
+    test: 'ava --require babel-register',
     tdd: 'npm test -- --watch',
     deps: ['ava@^0.14.0', 'chokidar@^1.4.3'],
   },

--- a/app/test-frameworks.js
+++ b/app/test-frameworks.js
@@ -10,9 +10,9 @@ var testFrameworksHash = {
     deps: ['tap-spec@^4.1.1', 'tape@^4.4.0', 'chokidar-cli@^1.2.0'],
   },
   ava: {
-    test: 'ava --require babel-register',
+    test: 'ava --require babel-register --timeout=2s',
     tdd: 'npm test -- --watch',
-    deps: ['ava@^0.13.0', 'chokidar@^1.4.3'],
+    deps: ['ava@^0.14.0', 'chokidar@^1.4.3'],
   },
 };
 


### PR DESCRIPTION
The `npm run tdd` hangs if there is no response from tests with promises. The [new ava version](https://github.com/sindresorhus/ava/releases/tag/v0.14.0) brings a `--timeout` flag that will stop test execution after a certain period of inactivity, so we won't need to restart `tdd` manually.