### PR TITLE
Clean obsolete

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,7 +2,6 @@
 /* eslint-disable func-names, vars-on-top, no-underscore-dangle */
 
 var yeoman = require('yeoman-generator');
-var humanizeUrl = require('humanize-url');
 var camelize = require('underscore.string').camelize;
 var R = require('ramda');
 var cat = require('./cat');
@@ -229,7 +228,6 @@ module.exports = yeoman.Base.extend({
       name: this.props.name,
       email: this.props.email,
       website: this.props.website,
-      humanizedWebsite: humanizeUrl(this.props.website),
       npmTestString: this.testFramework.test,
       npmTddString: this.testFramework.tdd
     };
@@ -242,7 +240,6 @@ module.exports = yeoman.Base.extend({
     cpTpl('_package.json', 'package.json');
     cpTpl('_README.md', 'README.md');
     cpTpl('editorconfig', '.editorconfig');
-    cpTpl('gitignore', '.gitignore');
     cpTpl('gitignore', '.gitignore');
     cpTpl('CHANGELOG.md', 'CHANGELOG.md');
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha -t 60000",
+    "test": "mocha -t 10000",
     "tdd": "npm test -- --watch",
     "postpublish": "git push --follow-tags"
   },

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "generator-eslint-init": "^1.0.0",
     "generator-git-init": "^1.1.0",
     "generator-travis": "^1.3.0",
-    "humanize-url": "^1.0.1",
     "if-empty": "^1.0.0",
     "mkdirp": "^0.5.1",
     "normalize-url": "^1.3.0",

--- a/test.js
+++ b/test.js
@@ -44,7 +44,7 @@ it('generates expected files', function (done) {
 it('generates expected files without appveyor', function (done) {
   helpers.run(path.join(__dirname, './app'))
     .withOptions({ all: true })
-    .withPrompts(R.merge(defaults, { appveyorSupport: false }))
+    .withPrompts(R.merge(defaults, { appveyorSupport: false, moduleTest: 'tape' }))
     .on('end', function () {
       assert.noFile('appveyor.yml');
       assert.fileContent('README.md', '[![Build Status][travis-image]][travis-url]');


### PR DESCRIPTION
**Sources:**
- Removed the duplicate creation of `.gitignore`.
- Removed `humanizeUrl`dependency and usage. ( Field was removed from the template in 8b7647f7. So it is no longer needed).

**Tests:**
- Reduced the timeout. 10s should be more than enough.
-  Fixed failing test, when no AppVeyor present. The "moduleTest" was not set and that resulted in an error.
